### PR TITLE
Feat: Add role field to registration form

### DIFF
--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -210,6 +210,17 @@ export default function Login() {
                       required
                     />
                   </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="register-role">Rôle (entrez "admin" pour les privilèges admin)</Label>
+                    <Input
+                      id="register-role"
+                      type="text"
+                      value={registerForm.role}
+                      onChange={(e) =>
+                        setRegisterForm({ ...registerForm, role: e.target.value })
+                      }
+                    />
+                  </div>
                   <Button type="submit" className="w-full" disabled={isLoading}>
                     {isLoading ? "Création..." : "Créer mon compte"}
                   </Button>


### PR DESCRIPTION
This commit adds a 'Role' input field to the registration form on the login page. This is a temporary measure to allow the site administrator to create an admin account by entering 'admin' in the field during registration.

This change is intended to be reverted for security reasons after the administrator has successfully created their account.