### PR TITLE
Fix(server): Add .js extension to vite.config import

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import path from "path";
 import { createServer as createViteServer, createLogger } from "vite";
 import { type Server } from "http";
-import viteConfig from "../vite.config";
+import viteConfig from "../vite.config.js";
 import { nanoid } from "nanoid";
 
 const viteLogger = createLogger();


### PR DESCRIPTION
This commit resolves the final `ERR_MODULE_NOT_FOUND` error by correcting a missed relative import path in `server/vite.ts`.

The import for `vite.config` was missing the `.js` extension, which is required by the Node.js ESM runtime on Vercel.

This was the last known bug of this type. With this fix, the server should now run without any module resolution errors.