### PR TITLE
Fix: Add direct dependency for @rollup/rollup-linux-x64-gnu

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@types/react-dom": "^18.3.1",
     "@types/ws": "^8.5.13",
     "@vitejs/plugin-react": "^4.3.2",
+    "@rollup/rollup-linux-x64-gnu": "^4.18.0",
     "autoprefixer": "^10.4.20",
     "drizzle-kit": "^0.30.4",
     "esbuild": "^0.25.0",


### PR DESCRIPTION
This is a last-resort attempt to fix a stubborn `ERR_MODULE_NOT_FOUND` error for an optional dependency on Vercel.

Despite removing the `package-lock.json`, the Vercel build environment is still failing to install or locate `@rollup/rollup-linux-x64-gnu`.

This change adds the package as a direct `devDependency` to force `npm` to install it explicitly. This should work around any issues `npm` has with resolving this specific optional dependency on the Vercel platform.