### PR TITLE
Fix: Switch to pnpm to resolve dependency bug

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+# This file signals to Vercel to use the pnpm package manager.

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "version": 2,
+  "installCommand": "pnpm install",
   "buildCommand": "npm run build",
   "devCommand": "npm run dev",
   "outputDirectory": "dist",


### PR DESCRIPTION
This commit switches the Vercel deployment to use the `pnpm` package manager instead of `npm`.

This is a final attempt to resolve a persistent `ERR_MODULE_NOT_FOUND` for the optional dependency `@rollup/rollup-linux-x64-gnu`. Previous attempts to fix this by removing the lockfile and adding a direct dependency have failed, indicating a deep issue between `npm` and the Vercel build environment.

Changes:
- Added `pnpm-workspace.yaml` to signal Vercel to use `pnpm`.
- Explicitly set `installCommand` to `pnpm install` in `vercel.json` for robustness.

`pnpm` has a different dependency resolution strategy that should bypass this platform-specific `npm` bug.