### PR TITLE
Fix: Simplify Vercel configuration to resolve function count limit er…

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,13 +1,6 @@
 {
   "version": 2,
-  "buildCommand": "npm run build",
-  "devCommand": "npm run dev",
-  "outputDirectory": "dist/public",
   "builds": [
-    {
-      "src": "package.json",
-      "use": "@vercel/static-build"
-    },
     {
       "src": "server/index.ts",
       "use": "@vercel/node"
@@ -15,12 +8,8 @@
   ],
   "routes": [
     {
-      "src": "/api/(.*)",
-      "dest": "server/index.ts"
-    },
-    {
       "src": "/(.*)",
-      "dest": "/dist/public/$1"
+      "dest": "server/index.ts"
     }
   ]
 }


### PR DESCRIPTION
…ror.

The previous vercel.json configuration was causing too many serverless functions to be created, exceeding the Hobby plan limit. This change simplifies the configuration to use a single serverless function that handles all requests. The Express server is responsible for serving the static frontend assets and handling API routes.