### PR TITLE
Fix: Explicitly force yarn install in Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "version": 2,
+  "installCommand": "yarn install",
   "builds": [
     {
       "src": "server/index.ts",


### PR DESCRIPTION
As a last resort to fix the persistent Rollup build error, this commit adds 'installCommand: "yarn install"' to the vercel.json file. This is to ensure Vercel uses Yarn to install dependencies, in case it was ignoring the yarn.lock file.