### PR TITLE
Fix: Explicitly set Content-Type for index.html

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -80,6 +80,7 @@ export function serveStatic(app: Express) {
 
   // fall through to index.html if the file doesn't exist
   app.use("*", (_req, res) => {
+    res.setHeader('Content-Type', 'text/html');
     res.sendFile(path.resolve(distPath, "index.html"));
   });
 }


### PR DESCRIPTION
To address an issue where the deployed application was serving raw code instead of rendering the HTML page, this commit explicitly sets the 'Content-Type' header to 'text/html' before serving the index.html file in production. This ensures the browser interprets the file correctly.