### PR TITLE
Refactor: Split build scripts for client and server

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
-    "vercel-build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
-    "start": "NODE_ENV=production node dist/index.js",
+    "build:client": "vite build",
+    "build:server": "esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist/server",
+    "build": "npm run build:client && npm run build:server",
+    "vercel-build": "npm run build",
+    "start": "NODE_ENV=production node dist/server/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate"

--- a/vercel.json
+++ b/vercel.json
@@ -7,14 +7,14 @@
       "config": { "distDir": "dist/public" }
     },
     {
-      "src": "dist/index.js",
+      "src": "dist/server/index.js",
       "use": "@vercel/node"
     }
   ],
   "routes": [
     {
       "src": "/api/(.*)",
-      "dest": "/dist/index.js"
+      "dest": "/dist/server/index.js"
     },
     {
       "handle": "filesystem"


### PR DESCRIPTION
As requested by the user, this commit refactors the build process to use separate scripts for the client and server builds ('build:client' and 'build:server').

- The main 'build' script now orchestrates these two scripts.
- The 'start' script and 'vercel.json' configuration have been updated to point to the new server output path at 'dist/server/index.js'.

This change improves the clarity and maintainability of the build process.