### PR TITLE
Fix: Correct database insert during user registration

### DIFF
--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import bcrypt from 'bcryptjs';
 import { db } from '@/lib/db';
-import { users, insertUserSchema } from '@/shared/schema';
+import { users, userStats, insertUserSchema } from '@/shared/schema';
 import { eq } from 'drizzle-orm';
 
 export async function POST(req: Request) {
@@ -39,7 +39,7 @@ export async function POST(req: Request) {
         }).returning();
 
         // Initialize stats for the new user, as was done in the legacy code
-        await tx.insert(users).values({ id: createdUser.id });
+        await tx.insert(userStats).values({ userId: createdUser.id });
 
         return createdUser;
     });


### PR DESCRIPTION
This commit fixes a critical bug in the user registration API route. The code was attempting to insert into the 'users' table twice, instead of creating an initial entry in the 'userStats' table for the new user. This caused a database error and prevented registration from succeeding.

The fix involves changing the target table for the second insert to 'userStats' and using the correct column name ('userId'), as was intended from the legacy application logic.