### PR TITLE
Fix: Refactor Express server for Vercel serverless environment

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -59,36 +59,20 @@ app.use((req, res, next) => {
   next();
 });
 
-(async () => {
-  const server = await registerRoutes(app);
+// Register API routes
+registerRoutes(app);
 
-  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
-    const status = err.status || err.statusCode || 500;
-    const message = err.message || "Internal Server Error";
+// Static file serving for production
+if (process.env.NODE_ENV === "production") {
+  serveStatic(app);
+}
 
-    res.status(status).json({ message });
-    throw err;
-  });
+// Global error handler
+app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
+  const status = err.status || err.statusCode || 500;
+  const message = err.message || "Internal Server Error";
+  console.error(err);
+  res.status(status).json({ message });
+});
 
-  // importantly only setup vite in development and after
-  // setting up all the other routes so the catch-all route
-  // doesn't interfere with the other routes
-  if (app.get("env") === "development") {
-    await setupVite(app, server);
-  } else {
-    serveStatic(app);
-  }
-
-  // ALWAYS serve the app on the port specified in the environment variable PORT
-  // Other ports are firewalled. Default to 5000 if not specified.
-  // this serves both the API and the client.
-  // It is the only port that is not firewalled.
-  const port = parseInt(process.env.PORT || '5000', 10);
-  server.listen({
-    port,
-    host: "0.0.0.0",
-    reusePort: true,
-  }, () => {
-    log(`serving on port ${port}`);
-  });
-})();
+export default app;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,5 +1,4 @@
 import type { Express } from "express";
-import { createServer, type Server } from "http";
 import { storage } from "./storage.js";
 import { AuthService, requireAuth, requireAdmin } from "./auth.js";
 import { insertCravingEntrySchema, insertExerciseSessionSchema, insertBeckAnalysisSchema, insertUserSchema, insertExerciseSchema, insertPsychoEducationContentSchema } from "../shared/schema.js";
@@ -7,7 +6,7 @@ import { z } from "zod";
 import { db } from './db.js';
 import { sql } from 'drizzle-orm';
 
-export async function registerRoutes(app: Express): Promise<Server> {
+export function registerRoutes(app: Express) {
 
   app.get("/api/test-db", async (_req, res) => {
     try {
@@ -303,6 +302,4 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  const httpServer = createServer(app);
-  return httpServer;
 }

--- a/vercel.json
+++ b/vercel.json
@@ -4,23 +4,17 @@
     {
       "src": "package.json",
       "use": "@vercel/static-build",
-      "config": {
-        "buildCommand": "npm run build:client",
-        "outputDir": "dist/public"
-      }
+      "config": { "distDir": "dist/public" }
     },
     {
-      "src": "server/index.ts",
-      "use": "@vercel/node",
-      "config": {
-        "buildCommand": "npm run build:server"
-      }
+      "src": "dist/server/index.js",
+      "use": "@vercel/node"
     }
   ],
   "routes": [
     {
       "src": "/api/(.*)",
-      "dest": "server/index.ts"
+      "dest": "/dist/server/index.js"
     },
     {
       "handle": "filesystem"


### PR DESCRIPTION
This commit fixes a fundamental issue preventing the Express server from running on Vercel. The server was previously calling `app.listen()`, which is incorrect for a serverless function. The platform handles listening.

Changes:
- `server/index.ts` is modified to `export default app` instead of creating an HTTP server and listening on a port.
- `server/routes.ts` is updated to align with the new serverless structure.
- `vercel.json` is configured to correctly point to the built serverless function output.

This finally aligns the application with Vercel's expected architecture and should resolve the persistent 404 errors.