### PR TITLE
Fix(vercel): Correct deployment configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
       "src": "package.json",
       "use": "@vercel/static-build",
       "config": {
-        "buildCommand": "npm run build:client",
+        "buildCommand": "npm run build",
         "outputDir": "dist/public"
       }
     },
@@ -23,4 +23,8 @@
       "handle": "filesystem"
     },
     {
-      "src": "
+      "src": "/(.*)",
+      "dest": "/dist/public/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
The vercel.json file was syntactically incorrect and incomplete, which prevented successful deployments.

This commit fixes the following issues:
- Corrects the invalid JSON syntax in the `routes` array.
- Updates the `buildCommand` to `npm run build` to ensure both the client and server are built, instead of only the client.
- Adds a catch-all route to serve the SPA's `index.html`, enabling client-side routing.